### PR TITLE
Fixed atomic boolean

### DIFF
--- a/mbed-platform/platform/source/mbed_error.c
+++ b/mbed-platform/platform/source/mbed_error.c
@@ -49,7 +49,7 @@ static void print_error_report(const mbed_error_ctx *ctx, const char *, const ch
 #define ERROR_REPORT(ctx, error_msg, error_filename, error_line) ((void) 0)
 #endif
 
-bool mbed_error_in_progress;
+atomic_bool mbed_error_in_progress;
 static atomic_flag halt_in_progress = ATOMIC_FLAG_INIT;
 static int error_count = 0;
 static mbed_error_ctx first_error_ctx = {0};


### PR DESCRIPTION
In the C standard, it is defined that atomic operation can only be performed on atomic types. GCC does not conform to that, so it will compile an ill-formed C program (essentially allowing atomic operations on basic types). LLVM, however, does not support that. This fixes one such variable so that LLVM can compile this project.

More info: https://stackoverflow.com/questions/46354210/c11-mixing-atomic-and-non-atomic-access-to-variable