### PR TITLE
Feature/memory pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,35 @@ mbed-benchtest provides tools for testing your Mbed applications on a desktop co
 ### RTXOff
 RTX Off-Board is a modified version of Mbed's RTX RTOS that runs on a desktop computer and translates RTOS calls to the host PC's threading library.  Using it, you can run multithreaded MBed applications in an environment very similar to a real processor.
 
+### Directory structure
+#### mbed-platform
+Copied from MBed, with some modifications (TODO: describe those modifications). These files the outward interface of MBedOS that is used by firmware code.
+
+#### RTXoff
+The implementation of MBed's RTX RTOS for the host OS. Implements the CMSIS API. Most code is copied from mbed, with many system-specific modifications.
+
+#### tests
+##### arm-cmsis-rtos-validator 
+Taken from [this repository](https://github.com/xpacks/arm-cmsis-rtos-validator), this validator is used to validate the RTXOff implementation
+
+##### events
+TODO, guessing those are additional tests for Events specifically?
+
+##### med-testing-frameworks
+TODO, I'm unfamiliar with these frameworks and how they're used.
+
+### Detailed behavior
 RTXOff uses nearly the same exact same thread scheduling code as RTX itself, so its thread switching behavior should be very similar to that of the RTOS on a real target.  Just like RTX, the scheduler will always immediately switch to the highest priority thread that can currently run.  Also note that at most one RTX thread can be running (as in, not suspended) at the same time.
 
+#### Preemptive scheduling
 The only place where RTXOff will have different behavior than RTX is preemptive scheduling -- when the scheduler interrupts your code at a scheduled time.  This behavior is what switches threads in a round-robin method to share the CPU, and it's also what takes sleeping threads off the waiting list and runs them at the correct time.  RTXOff guarantees that preemptive scheduling will *do* the same thing, but not that it will *happen* at the same time.  So if your code is sensitive to differences in when scheduling interrupts happen, it may run differently under RTXOff. 
 
 Note that these timing inaccuracies also apply to timed waits in certain cases because it can take a fair amount of time for the scheduler to wake up from sleep or switch away from the idle thread.  On real systems I see about +-20ms accuracy on timeouts and delay times using the more accurate `RTXOFF_USE_PROCESS_CLOCK=1` setting (measured using the kernel's own clock).  On a real system, these would be accurate to the scheduler tick (default 1ms).  Note that this is _only_ an issue with wait timeouts -- thread switches due to one thread blocking (or doing something else that causes a switch such as starting a new high-priority thread) happen almost immediately, just like the real processor.
 
+#### Interrupt suppors
 RTXOff supports interrupts, using the standard [NVIC interrupt functions](https://www.keil.com/pack/doc/CMSIS/Core/html/group__NVIC__gr.html).  This allows you to test code that uses interrupts in a reasonable way -- just write testing code that calls NVIC_EnableIRQ() at the appropriate time to trigger an interrupt in your code.  Note that the NVIC_XXX functions are safe to call from any thread, unlike all other cmsis-rtos API functions which are only safe to call from RTOS threads.  RTXOff interrupts do support priority (the interrupt with lowest priority value will be delivered first if multiple are triggered), but they do *not* support interrupting a currently executing interrupt with another interrupt (which is what happens on the processor if a higher priority interrupt is triggered).  Instead, the new interrupt will be executed as soon as the current one returns.
 
-**Current Limitations / Things to Know**:
+### Current Limitations / Things to Know
 - Main Function: Without toolchain support, there's no way to override your app's main() function.  So, your app's main should be called `int mbed_start()` (`extern "C" int mbed_start()` if in C++).  RTXOff's main thread will call this function when it starts.
 - RTXOff does not use or check the memory that your code allocates for RTOS objects and thread stacks.  Even if RTXOff did check stack sizes, your program's stack would be a different size when compiled for desktop than when built for ARM.  So, you cannot verify that your threads have enough stack space to run with RTXOff.
 - The scheduler tick frequency must be between 1Hz-1000Hz (so the tick period must be between 1ms-1000ms)

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ The implementation of MBed's RTX RTOS for the host OS. Implements the CMSIS API.
 Taken from [this repository](https://github.com/xpacks/arm-cmsis-rtos-validator), this validator is used to validate the RTXOff implementation
 
 ##### events
-TODO, guessing those are additional tests for Events specifically?
+Tests for the Mbed OS event queue functionality.  We used these to help validate that both threads and event queues were working. 
 
-##### med-testing-frameworks
-TODO, I'm unfamiliar with these frameworks and how they're used.
+##### mbed-testing-frameworks
+Dependencies for Mbed unit tests such as those in the events folder.  Modified by us to run on desktop.
 
 ### Detailed behavior
 RTXOff uses nearly the same exact same thread scheduling code as RTX itself, so its thread switching behavior should be very similar to that of the RTOS on a real target.  Just like RTX, the scheduler will always immediately switch to the highest priority thread that can currently run.  Also note that at most one RTX thread can be running (as in, not suspended) at the same time.
@@ -29,7 +29,7 @@ The only place where RTXOff will have different behavior than RTX is preemptive 
 
 Note that these timing inaccuracies also apply to timed waits in certain cases because it can take a fair amount of time for the scheduler to wake up from sleep or switch away from the idle thread.  On real systems I see about +-20ms accuracy on timeouts and delay times using the more accurate `RTXOFF_USE_PROCESS_CLOCK=1` setting (measured using the kernel's own clock).  On a real system, these would be accurate to the scheduler tick (default 1ms).  Note that this is _only_ an issue with wait timeouts -- thread switches due to one thread blocking (or doing something else that causes a switch such as starting a new high-priority thread) happen almost immediately, just like the real processor.
 
-#### Interrupt suppors
+#### Interrupt support
 RTXOff supports interrupts, using the standard [NVIC interrupt functions](https://www.keil.com/pack/doc/CMSIS/Core/html/group__NVIC__gr.html).  This allows you to test code that uses interrupts in a reasonable way -- just write testing code that calls NVIC_EnableIRQ() at the appropriate time to trigger an interrupt in your code.  Note that the NVIC_XXX functions are safe to call from any thread, unlike all other cmsis-rtos API functions which are only safe to call from RTOS threads.  RTXOff interrupts do support priority (the interrupt with lowest priority value will be delivered first if multiple are triggered), but they do *not* support interrupting a currently executing interrupt with another interrupt (which is what happens on the processor if a higher priority interrupt is triggered).  Instead, the new interrupt will be executed as soon as the current one returns.
 
 ### Current Limitations / Things to Know

--- a/RTXOff/CMakeLists.txt
+++ b/RTXOff/CMakeLists.txt
@@ -32,6 +32,7 @@ set(RTX_OFF_SOURCES
 	rtxoff_delay.cpp
 	rtxoff_evflags.cpp
 	rtxoff_semaphore.cpp
+	rtxoff_mempool.cpp
 	ThreadDispatcher.cpp
 	ThreadDispatcher.h
 	rtxoff_clock.h

--- a/RTXOff/cmsis_os1.c
+++ b/RTXOff/cmsis_os1.c
@@ -160,7 +160,6 @@ int32_t osSemaphoreWait (osSemaphoreId semaphore_id, uint32_t millisec) {
 
 #endif  // Semaphore
 
-/*
 // Memory Pool
 
 #if (defined(osFeature_Pool) && (osFeature_Pool != 0))&& !defined(os1_Disable_Pool)
@@ -198,6 +197,7 @@ osStatus osPoolFree (osPoolId pool_id, void *block) {
 
 #endif  // Memory Pool
 
+/*
 
 // Message Queue
 

--- a/RTXOff/rtxoff_internal.h
+++ b/RTXOff/rtxoff_internal.h
@@ -33,7 +33,7 @@ void osRtxThreadBlock (osRtxThread_t *thread);
 void osRtxThreadListUnlink (osRtxThread_t **thread_list, osRtxThread_t *thread);
 void osRtxThreadReadyPut (osRtxThread_t * thread);
 void *osRtxThreadListRoot (osRtxThread_t *thread);
-void osRtxThreadWaitExit(osRtxThread_t *thread, uint32_t ret_val, bool dispatch);
+void osRtxThreadWaitExit(osRtxThread_t *thread, uint64_t ret_val, bool dispatch);
 bool osRtxThreadWaitEnter (uint8_t state, uint32_t timeout);
 
 // Mutex Library functions

--- a/RTXOff/rtxoff_mempool.cpp
+++ b/RTXOff/rtxoff_mempool.cpp
@@ -448,7 +448,6 @@ static osStatus_t svcRtxMemoryPoolDelete(osMemoryPoolId_t mp_id) {
         // at this point a new thread might potentially take over
         ThreadDispatcher::instance().dispatch(nullptr);
 
-        // TODO unclear whether the above is enough
         if (ThreadDispatcher::instance().thread.run.curr->state != osRtxThreadRunning) {
             // other thread has higher priority, switch to it
             ThreadDispatcher::instance().blockUntilWoken();

--- a/RTXOff/rtxoff_mempool.cpp
+++ b/RTXOff/rtxoff_mempool.cpp
@@ -1,0 +1,682 @@
+//
+// RTXOff mempool functionality
+//
+
+#include <cstring>
+#include "ThreadDispatcher.h"
+
+
+//  ==== Library functions ====
+
+/// Initialize Memory Pool.
+/// \param[in]  mp_info         memory pool info.
+/// \param[in]  block_count     maximum number of memory blocks in memory pool.
+/// \param[in]  block_size      size of a memory block in bytes.
+/// \param[in]  block_mem       pointer to memory for block storage.
+/// \return 1 - success, 0 - failure.
+uint32_t osRtxMemoryPoolInit(osRtxMpInfo_t *mp_info, uint32_t block_count, uint32_t block_size, void *block_mem) {
+    //lint --e{9079} --e{9087} "conversion from pointer to void to pointer to other type" [MISRA Note 6]
+    void *mem;
+    void *block;
+
+    // Check parameters
+    if ((mp_info == nullptr) || (block_count == 0U) || (block_size == 0U) || (block_mem == nullptr)) {
+        //lint -e{904} "Return statement before end of function" [MISRA Note 1]
+        return 0U;
+    }
+
+    // Initialize information structure
+    mp_info->max_blocks = block_count;
+    mp_info->used_blocks = 0U;
+    mp_info->block_size = block_size;
+    mp_info->block_base = block_mem;
+    mp_info->block_free = block_mem;
+    mp_info->block_lim = &(((uint8_t *) block_mem)[block_count * block_size]);
+
+    // TODO add event
+    // EvrRtxMemoryBlockInit(mp_info, block_count, block_size, block_mem);
+
+    // Link all free blocks
+    mem = block_mem;
+    while (--block_count != 0U) {
+        block = &((uint8_t *) mem)[block_size];
+        *((void **) mem) = block;
+        mem = block;
+    }
+    *((void **) mem) = nullptr;
+
+    return 1U;
+}
+
+/// Allocate a memory block from a Memory Pool.
+/// \param[in]  mp_info         memory pool info.
+/// \return address of the allocated memory block or nullptr in case of no memory is available.
+void *osRtxMemoryPoolAlloc(osRtxMpInfo_t *mp_info) {
+
+    void *block;
+
+    if (mp_info == nullptr) {
+        // TODO add event
+        // EvrRtxMemoryBlockAlloc(nullptr, nullptr);
+        //lint -e{904} "Return statement before end of function" [MISRA Note 1]
+        return nullptr;
+    }
+
+    {
+        ThreadDispatcher::Mutex mutex;
+        block = mp_info->block_free;
+        if (block != nullptr) {
+            mp_info->block_free = *((void **) block);
+            mp_info->used_blocks++;
+        }
+    }
+    // TODO add event
+    // EvrRtxMemoryBlockAlloc(mp_info, block);
+
+    return block;
+}
+
+/// Return an allocated memory block back to a Memory Pool.
+/// \param[in]  mp_info         memory pool info.
+/// \param[in]  block           address of the allocated memory block to be returned to the memory pool.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osRtxMemoryPoolFree(osRtxMpInfo_t *mp_info, void *block) {
+
+    //lint -e{946} "Relational operator applied to pointers"
+    if ((mp_info == nullptr) || (block < mp_info->block_base) || (block >= mp_info->block_lim)) {
+        // TODO add event
+        // EvrRtxMemoryBlockFree(mp_info, block, (int32_t) osErrorParameter);
+        //lint -e{904} "Return statement before end of function" [MISRA Note 1]
+        return osErrorParameter;
+    }
+
+    {
+        ThreadDispatcher::Mutex mutex;
+        //lint --e{9079} --e{9087} "conversion from pointer to void to pointer to other type"
+        *((void **) block) = mp_info->block_free;
+        mp_info->block_free = block;
+        mp_info->used_blocks--;
+    }
+
+    // TODO add event
+    // EvrRtxMemoryBlockFree(mp_info, block, (int32_t) osOK);
+
+    return osOK;
+}
+
+
+//  ==== Post ISR processing ====
+
+/// Memory Pool post ISR processing.
+/// \param[in]  mp              memory pool object.
+static void osRtxMemoryPoolPostProcess(osRtxMemoryPool_t *mp) {
+    void *block;
+    osRtxThread_t *thread;
+
+    // Check if Thread is waiting to allocate memory
+    if (mp->thread_list != nullptr) {
+        // Allocate memory
+        block = osRtxMemoryPoolAlloc(&mp->mp_info);
+        if (block != nullptr) {
+            // Wakeup waiting Thread with highest Priority
+            thread = osRtxThreadListGet(reinterpret_cast<osRtxObject_t *>(mp));
+            //lint -e{923} "cast from pointer to unsigned int"
+            osRtxThreadWaitExit(thread, (uint64_t) block, false);
+            // TODO add event
+            // EvrRtxMemoryPoolAllocated(mp, block);
+        }
+    }
+}
+
+
+//  ==== Service Calls ====
+
+/// Create and Initialize a Memory Pool object.
+/// \note API identical to osMemoryPoolNew
+static osMemoryPoolId_t svcRtxMemoryPoolNew(uint32_t block_count, uint32_t block_size, const osMemoryPoolAttr_t *attr) {
+    osRtxMemoryPool_t *mp;
+    void *mp_mem;
+    uint32_t mp_size;
+    uint32_t b_count;
+    uint32_t b_size;
+    uint32_t size;
+    uint8_t flags;
+    const char *name;
+
+    // Check parameters
+    if ((block_count == 0U) || (block_size == 0U)) {
+        // TODO add event
+        // EvrRtxMemoryPoolError(nullptr, (int32_t) osErrorParameter);
+        //lint -e{904} "Return statement before end of function" [MISRA Note 1]
+        return nullptr;
+    }
+    b_count = block_count;
+    b_size = (block_size + 3U) & ~3UL;
+    if ((__builtin_clz(b_count) + __builtin_clz(b_size)) < 32U) {
+        // TODO add event
+        // EvrRtxMemoryPoolError(nullptr, (int32_t) osErrorParameter);
+        //lint -e{904} "Return statement before end of function" [MISRA Note 1]
+        return nullptr;
+    }
+
+    size = b_count * b_size;
+
+    // Process attributes
+    if (attr != nullptr) {
+        name = attr->name;
+        //lint -e{9079} "conversion from pointer to void to pointer to other type" [MISRA Note 6]
+        mp = static_cast<osRtxMemoryPool_t *>(attr->cb_mem);
+        //lint -e{9079} "conversion from pointer to void to pointer to other type" [MISRA Note 6]
+        mp_mem = attr->mp_mem;
+        mp_size = attr->mp_size;
+        if (mp != nullptr) {
+            //lint -e(923) -e(9078) "cast from pointer to unsigned int" [MISRA Note 7]
+            if ((((uint64_t) mp & 3U) != 0U) || (attr->cb_size < sizeof(osRtxMemoryPool_t))) {
+                // TODO add event
+                // EvrRtxMemoryPoolError(nullptr, osRtxErrorInvalidControlBlock);
+                //lint -e{904} "Return statement before end of function" [MISRA Note 1]
+                return nullptr;
+            }
+        } else {
+            if (attr->cb_size != 0U) {
+                // TODO add event
+                // EvrRtxMemoryPoolError(nullptr, osRtxErrorInvalidControlBlock);
+                //lint -e{904} "Return statement before end of function" [MISRA Note 1]
+                return nullptr;
+            }
+        }
+        if (mp_mem != nullptr) {
+            //lint -e(923) -e(9078) "cast from pointer to unsigned int" [MISRA Note 7]
+            if ((((uint64_t) mp_mem & 3U) != 0U) || (mp_size < size)) {
+                // TODO add event
+                // EvrRtxMemoryPoolError(nullptr, osRtxErrorInvalidDataMemory);
+                //lint -e{904} "Return statement before end of function" [MISRA Note 1]
+                return nullptr;
+            }
+        } else {
+            if (mp_size != 0U) {
+                // TODO add event
+                // EvrRtxMemoryPoolError(nullptr, osRtxErrorInvalidDataMemory);
+                //lint -e{904} "Return statement before end of function" [MISRA Note 1]
+                return nullptr;
+            }
+        }
+    } else {
+        name = nullptr;
+        mp = nullptr;
+        mp_mem = nullptr;
+    }
+
+    // Allocate object memory if not provided
+    if (mp == nullptr) {
+        if (osRtxInfo_t.mpi.memory_pool != nullptr) {
+            //lint -e{9079} "conversion from pointer to void to pointer to other type" [MISRA Note 5]
+            mp = osRtxMemoryPoolAlloc(osRtxInfo.mpi.memory_pool);
+        } else {
+            //lint -e{9079} "conversion from pointer to void to pointer to other type" [MISRA Note 5]
+            mp = osRtxMemoryAlloc(osRtxInfo.mem.common, sizeof(osRtxMemoryPool_t), 1U);
+        }
+
+        flags = osRtxFlagSystemObject;
+    } else {
+        flags = 0U;
+    }
+
+    // Allocate data memory if not provided
+    if ((mp != nullptr) && (mp_mem == nullptr)) {
+        //lint -e{9079} "conversion from pointer to void to pointer to other type" [MISRA Note 5]
+        mp_mem = osRtxMemoryAlloc(osRtxInfo.mem.mp_data, size, 0U);
+        if (mp_mem == nullptr) {
+            if ((flags & osRtxFlagSystemObject) != 0U) {
+                if (osRtxInfo.mpi.memory_pool != nullptr) {
+                    (void) osRtxMemoryPoolFree(osRtxInfo.mpi.memory_pool, mp);
+                } else {
+                    (void) osRtxMemoryFree(osRtxInfo.mem.common, mp);
+                }
+
+            }
+            mp = nullptr;
+        } else {
+            memset(mp_mem, 0, size);
+        }
+        flags |= osRtxFlagSystemMemory;
+    }
+
+    if (mp != nullptr) {
+        // Initialize control block
+        mp->id = osRtxIdMemoryPool;
+        mp->flags = flags;
+        mp->name = name;
+        mp->thread_list = nullptr;
+        (void) osRtxMemoryPoolInit(&mp->mp_info, b_count, b_size, mp_mem);
+
+        // Register post ISR processing function
+        osRtxInfo.post_process.memory_pool = osRtxMemoryPoolPostProcess;
+
+        // TODO add event
+        // EvrRtxMemoryPoolCreated(mp, mp->name);
+    } else {
+        // TODO add event
+        // EvrRtxMemoryPoolError(nullptr, (int32_t) osErrorNoMemory);
+    }
+
+    return mp;
+}
+
+/// Get name of a Memory Pool object.
+/// \note API identical to osMemoryPoolGetName
+static const char *svcRtxMemoryPoolGetName(osMemoryPoolId_t mp_id) {
+    osRtxMemoryPool_t *mp = osRtxMemoryPoolId(mp_id);
+
+    // Check parameters
+    if ((mp == nullptr) || (mp->id != osRtxIdMemoryPool)) {
+        // TODO add event
+        // EvrRtxMemoryPoolGetName(mp, nullptr);
+        //lint -e{904} "Return statement before end of function" [MISRA Note 1]
+        return nullptr;
+    }
+
+    // TODO add event
+    // EvrRtxMemoryPoolGetName(mp, mp->name);
+
+    return mp->name;
+}
+
+/// Allocate a memory block from a Memory Pool.
+/// \note API identical to osMemoryPoolAlloc
+static void *svcRtxMemoryPoolAlloc(osMemoryPoolId_t mp_id, uint32_t timeout) {
+    osRtxMemoryPool_t *mp = osRtxMemoryPoolId(mp_id);
+    void *block;
+
+    // Check parameters
+    if ((mp == nullptr) || (mp->id != osRtxIdMemoryPool)) {
+        // TODO add event
+        // EvrRtxMemoryPoolError(mp, (int32_t) osErrorParameter);
+        //lint -e{904} "Return statement before end of function" [MISRA Note 1]
+        return nullptr;
+    }
+
+    // Allocate memory
+    block = osRtxMemoryPoolAlloc(&mp->mp_info);
+    if (block != nullptr) {
+        // TODO add event
+        // EvrRtxMemoryPoolAllocated(mp, block);
+    } else {
+        // No memory available
+        if (timeout != 0U) {
+            // TODO add event
+            // EvrRtxMemoryPoolAllocPending(mp, timeout);
+            // Suspend current Thread
+            if (osRtxThreadWaitEnter(osRtxThreadWaitingMemoryPool, timeout)) {
+                osRtxThreadListPut(osRtxObject(mp), osRtxThreadGetRunning());
+            } else {
+                // TODO add event
+                // EvrRtxMemoryPoolAllocTimeout(mp);
+            }
+        } else {
+            // TODO add event
+            // EvrRtxMemoryPoolAllocFailed(mp);
+        }
+    }
+
+    return block;
+}
+
+/// Return an allocated memory block back to a Memory Pool.
+/// \note API identical to osMemoryPoolFree
+static osStatus_t svcRtxMemoryPoolFree(osMemoryPoolId_t mp_id, void *block) {
+    osRtxMemoryPool_t *mp = osRtxMemoryPoolId(mp_id);
+    void *block0;
+    os_thread_t *thread;
+    osStatus_t status;
+
+    // Check parameters
+    if ((mp == nullptr) || (mp->id != osRtxIdMemoryPool)) {
+        // TODO add event
+        // EvrRtxMemoryPoolError(mp, (int32_t) osErrorParameter);
+        //lint -e{904} "Return statement before end of function" [MISRA Note 1]
+        return osErrorParameter;
+    }
+
+    // Free memory
+    status = osRtxMemoryPoolFree(&mp->mp_info, block);
+    if (status == osOK) {
+        // TODO add event
+        // EvrRtxMemoryPoolDeallocated(mp, block);
+        // Check if Thread is waiting to allocate memory
+        if (mp->thread_list != nullptr) {
+            // Allocate memory
+            block0 = osRtxMemoryPoolAlloc(&mp->mp_info);
+            if (block0 != nullptr) {
+                // Wakeup waiting Thread with highest Priority
+                thread = osRtxThreadListGet(osRtxObject(mp));
+                //lint -e{923} "cast from pointer to unsigned int"
+                osRtxThreadWaitExit(thread, (uint32_t) block0, TRUE);
+                // TODO add event
+                // EvrRtxMemoryPoolAllocated(mp, block0);
+            }
+        }
+    } else {
+        // TODO add event
+        // EvrRtxMemoryPoolFreeFailed(mp, block);
+    }
+
+    return status;
+}
+
+/// Get maximum number of memory blocks in a Memory Pool.
+/// \note API identical to osMemoryPoolGetCapacity
+static uint32_t svcRtxMemoryPoolGetCapacity(osMemoryPoolId_t mp_id) {
+    osRtxMemoryPool_t *mp = osRtxMemoryPoolId(mp_id);
+
+    // Check parameters
+    if ((mp == nullptr) || (mp->id != osRtxIdMemoryPool)) {
+        // TODO add event
+        // EvrRtxMemoryPoolGetCapacity(mp, 0U);
+        //lint -e{904} "Return statement before end of function" [MISRA Note 1]
+        return 0U;
+    }
+
+    // TODO add event
+    // EvrRtxMemoryPoolGetCapacity(mp, mp->mp_info.max_blocks);
+
+    return mp->mp_info.max_blocks;
+}
+
+/// Get memory block size in a Memory Pool.
+/// \note API identical to osMemoryPoolGetBlockSize
+static uint32_t svcRtxMemoryPoolGetBlockSize(osMemoryPoolId_t mp_id) {
+    osRtxMemoryPool_t *mp = osRtxMemoryPoolId(mp_id);
+
+    // Check parameters
+    if ((mp == nullptr) || (mp->id != osRtxIdMemoryPool)) {
+        // TODO add event
+        // EvrRtxMemoryPoolGetBlockSize(mp, 0U);
+        //lint -e{904} "Return statement before end of function" [MISRA Note 1]
+        return 0U;
+    }
+
+    // TODO add event
+    // EvrRtxMemoryPoolGetBlockSize(mp, mp->mp_info.block_size);
+
+    return mp->mp_info.block_size;
+}
+
+/// Get number of memory blocks used in a Memory Pool.
+/// \note API identical to osMemoryPoolGetCount
+static uint32_t svcRtxMemoryPoolGetCount(osMemoryPoolId_t mp_id) {
+    osRtxMemoryPool_t *mp = osRtxMemoryPoolId(mp_id);
+
+    // Check parameters
+    if ((mp == nullptr) || (mp->id != osRtxIdMemoryPool)) {
+        // TODO add event
+        // EvrRtxMemoryPoolGetCount(mp, 0U);
+        //lint -e{904} "Return statement before end of function" [MISRA Note 1]
+        return 0U;
+    }
+
+    // TODO add event
+    // EvrRtxMemoryPoolGetCount(mp, mp->mp_info.used_blocks);
+
+    return mp->mp_info.used_blocks;
+}
+
+/// Get number of memory blocks available in a Memory Pool.
+/// \note API identical to osMemoryPoolGetSpace
+static uint32_t svcRtxMemoryPoolGetSpace(osMemoryPoolId_t mp_id) {
+    osRtxMemoryPool_t *mp = osRtxMemoryPoolId(mp_id);
+
+    // Check parameters
+    if ((mp == nullptr) || (mp->id != osRtxIdMemoryPool)) {
+        // TODO add event
+        // EvrRtxMemoryPoolGetSpace(mp, 0U);
+        //lint -e{904} "Return statement before end of function" [MISRA Note 1]
+        return 0U;
+    }
+
+    // TODO add event
+    // EvrRtxMemoryPoolGetSpace(mp, mp->mp_info.max_blocks - mp->mp_info.used_blocks);
+
+    return (mp->mp_info.max_blocks - mp->mp_info.used_blocks);
+}
+
+/// Delete a Memory Pool object.
+/// \note API identical to osMemoryPoolDelete
+static osStatus_t svcRtxMemoryPoolDelete(osMemoryPoolId_t mp_id) {
+    osRtxMemoryPool_t *mp = osRtxMemoryPoolId(mp_id);
+    os_thread_t *thread;
+
+    // Check parameters
+    if ((mp == nullptr) || (mp->id != osRtxIdMemoryPool)) {
+        // TODO add event
+        // EvrRtxMemoryPoolError(mp, (int32_t) osErrorParameter);
+        //lint -e{904} "Return statement before end of function" [MISRA Note 1]
+        return osErrorParameter;
+    }
+
+    // Unblock waiting threads
+    if (mp->thread_list != nullptr) {
+        do {
+            thread = osRtxThreadListGet(osRtxObject(mp));
+            osRtxThreadWaitExit(thread, 0U, FALSE);
+        } while (mp->thread_list != nullptr);
+        osRtxThreadDispatch(nullptr);
+    }
+
+    // Mark object as invalid
+    mp->id = osRtxIdInvalid;
+
+    // Free data memory
+    if ((mp->flags & osRtxFlagSystemMemory) != 0U) {
+        (void) osRtxMemoryFree(osRtxInfo.mem.mp_data, mp->mp_info.block_base);
+    }
+
+    // Free object memory
+    if ((mp->flags & osRtxFlagSystemObject) != 0U) {
+        if (osRtxInfo.mpi.memory_pool != nullptr) {
+            (void) osRtxMemoryPoolFree(osRtxInfo.mpi.memory_pool, mp);
+        } else {
+            (void) osRtxMemoryFree(osRtxInfo.mem.common, mp);
+        }
+
+    }
+
+    // TODO add event
+    // EvrRtxMemoryPoolDestroyed(mp);
+
+    return osOK;
+}
+
+
+
+//  ==== ISR Calls ====
+
+/// Allocate a memory block from a Memory Pool.
+/// \note API identical to osMemoryPoolAlloc
+__STATIC_INLINE
+void *isrRtxMemoryPoolAlloc(osMemoryPoolId_t mp_id, uint32_t timeout) {
+    osRtxMemoryPool_t *mp = osRtxMemoryPoolId(mp_id);
+    void *block;
+
+    // Check parameters
+    if ((mp == nullptr) || (mp->id != osRtxIdMemoryPool) || (timeout != 0U)) {
+        // TODO add event
+        // EvrRtxMemoryPoolError(mp, (int32_t) osErrorParameter);
+        //lint -e{904} "Return statement before end of function" [MISRA Note 1]
+        return nullptr;
+    }
+
+    // Allocate memory
+    block = osRtxMemoryPoolAlloc(&mp->mp_info);
+    if (block == nullptr) {
+        // TODO add event
+        // EvrRtxMemoryPoolAllocFailed(mp);
+    } else {
+        // TODO add event
+        // EvrRtxMemoryPoolAllocated(mp, block);
+    }
+
+    return block;
+}
+
+/// Return an allocated memory block back to a Memory Pool.
+/// \note API identical to osMemoryPoolFree
+__STATIC_INLINE
+        osStatus_t
+isrRtxMemoryPoolFree (osMemoryPoolId_t
+mp_id,
+void *block
+) {
+osRtxMemoryPool_t *mp = osRtxMemoryPoolId(mp_id);
+osStatus_t status;
+
+// Check parameters
+if ((mp == nullptr) || (mp->id != osRtxIdMemoryPool)) {
+EvrRtxMemoryPoolError(mp, (int32_t)
+osErrorParameter);
+//lint -e{904} "Return statement before end of function" [MISRA Note 1]
+return
+osErrorParameter;
+}
+
+// Free memory
+status = osRtxMemoryPoolFree(&mp->mp_info, block);
+if (status == osOK) {
+// Register post ISR processing
+osRtxPostProcess(osRtxObject(mp)
+);
+EvrRtxMemoryPoolDeallocated(mp, block
+);
+} else {
+EvrRtxMemoryPoolFreeFailed(mp, block
+);
+}
+
+return
+status;
+}
+
+
+//  ==== Public API ====
+
+/// Create and Initialize a Memory Pool object.
+osMemoryPoolId_t osMemoryPoolNew(uint32_t block_count, uint32_t block_size, const osMemoryPoolAttr_t *attr) {
+    osMemoryPoolId_t mp_id;
+
+    // TODO add event
+    // EvrRtxMemoryPoolNew(block_count, block_size, attr);
+    if (IsIrqMode() || IsIrqMasked()) {
+        // TODO add event
+        // EvrRtxMemoryPoolError(nullptr, (int32_t) osErrorISR);
+        mp_id = nullptr;
+    } else {
+        mp_id = svcRtxMemoryPoolNew(block_count, block_size, attr);
+    }
+    return mp_id;
+}
+
+/// Get name of a Memory Pool object.
+const char *osMemoryPoolGetName(osMemoryPoolId_t mp_id) {
+    const char *name;
+
+    if (IsIrqMode() || IsIrqMasked()) {
+        // TODO add event
+        // EvrRtxMemoryPoolGetName(mp_id, nullptr);
+        name = nullptr;
+    } else {
+        name = svcRtxMemoryPoolGetName(mp_id);
+    }
+    return name;
+}
+
+/// Allocate a memory block from a Memory Pool.
+void *osMemoryPoolAlloc(osMemoryPoolId_t mp_id, uint32_t timeout) {
+    void *memory;
+
+    // TODO add event
+    // EvrRtxMemoryPoolAlloc(mp_id, timeout);
+    if (IsIrqMode() || IsIrqMasked()) {
+        memory = isrRtxMemoryPoolAlloc(mp_id, timeout);
+    } else {
+        memory = svcRtxMemoryPoolAlloc(mp_id, timeout);
+    }
+    return memory;
+}
+
+/// Return an allocated memory block back to a Memory Pool.
+osStatus_t osMemoryPoolFree(osMemoryPoolId_t mp_id, void *block) {
+    osStatus_t status;
+
+    // TODO add event
+    // EvrRtxMemoryPoolFree(mp_id, block);
+    if (IsIrqMode() || IsIrqMasked()) {
+        status = isrRtxMemoryPoolFree(mp_id, block);
+    } else {
+        status = svcRtxMemoryPoolFree(mp_id, block);
+    }
+    return status;
+}
+
+/// Get maximum number of memory blocks in a Memory Pool.
+uint32_t osMemoryPoolGetCapacity(osMemoryPoolId_t mp_id) {
+    uint32_t capacity;
+
+    if (IsIrqMode() || IsIrqMasked()) {
+        capacity = svcRtxMemoryPoolGetCapacity(mp_id);
+    } else {
+        capacity = svcRtxMemoryPoolGetCapacity(mp_id);
+    }
+    return capacity;
+}
+
+/// Get memory block size in a Memory Pool.
+uint32_t osMemoryPoolGetBlockSize(osMemoryPoolId_t mp_id) {
+    uint32_t block_size;
+
+    if (IsIrqMode() || IsIrqMasked()) {
+        block_size = svcRtxMemoryPoolGetBlockSize(mp_id);
+    } else {
+        block_size = svcRtxMemoryPoolGetBlockSize(mp_id);
+    }
+    return block_size;
+}
+
+/// Get number of memory blocks used in a Memory Pool.
+uint32_t osMemoryPoolGetCount(osMemoryPoolId_t mp_id) {
+    uint32_t count;
+
+    if (IsIrqMode() || IsIrqMasked()) {
+        count = svcRtxMemoryPoolGetCount(mp_id);
+    } else {
+        count = svcRtxMemoryPoolGetCount(mp_id);
+    }
+    return count;
+}
+
+/// Get number of memory blocks available in a Memory Pool.
+uint32_t osMemoryPoolGetSpace(osMemoryPoolId_t mp_id) {
+    uint32_t space;
+
+    if (IsIrqMode() || IsIrqMasked()) {
+        space = svcRtxMemoryPoolGetSpace(mp_id);
+    } else {
+        space = svcRtxMemoryPoolGetSpace(mp_id);
+    }
+    return space;
+}
+
+/// Delete a Memory Pool object.
+osStatus_t osMemoryPoolDelete(osMemoryPoolId_t mp_id) {
+    osStatus_t status;
+
+    // TODO add event
+    // EvrRtxMemoryPoolDelete(mp_id);
+    if (IsIrqMode() || IsIrqMasked()) {
+        // TODO add event
+        // EvrRtxMemoryPoolError(mp_id, (int32_t) osErrorISR);
+        status = osErrorISR;
+    } else {
+        status = svcRtxMemoryPoolDelete(mp_id);
+    }
+    return status;
+}

--- a/RTXOff/rtxoff_mempool.cpp
+++ b/RTXOff/rtxoff_mempool.cpp
@@ -239,7 +239,7 @@ static osMemoryPoolId_t svcRtxMemoryPoolNew(uint32_t block_count, uint32_t block
         (void) osRtxMemoryPoolInit(&mp->mp_info, b_count, b_size, mp_mem);
 
         // Register post ISR processing function
-        // TODO osRtxInfo.post_process.memory_pool = osRtxMemoryPoolPostProcess;
+        ThreadDispatcher::instance().post_process.memory_pool = osRtxMemoryPoolPostProcess;
 
         // add event
         // EvrRtxMemoryPoolCreated(mp, mp->name);
@@ -528,7 +528,7 @@ isrRtxMemoryPoolFree(osMemoryPoolId_t mp_id, void *block) {
     if (status == osOK) {
         // Register post ISR processing
 
-        // TODO osRtxPostProcess(reinterpret_cast<osRtxObject_t *>(mp));
+        ThreadDispatcher::instance().queuePostProcess(reinterpret_cast<osRtxObject_t *>(mp));
         // add event
         // EvrRtxMemoryPoolDeallocated(mp, block);
     } else {

--- a/RTXOff/rtxoff_os.h
+++ b/RTXOff/rtxoff_os.h
@@ -124,7 +124,7 @@ typedef struct osRtxThread_s {
   uint32_t               thread_flags;  ///< Thread Flags
   struct osRtxMutex_s     *mutex_list;  ///< Link pointer to list of owned Mutexes
 
-  uint32_t waitExitVal;                 // return value passed from osRtxThreadWaitExit().  Set only when this function is called, not when a thread wait timeout expires.
+  uint64_t waitExitVal;                 // return value passed from osRtxThreadWaitExit().  Set only when this function is called, not when a thread wait timeout expires.
   uint8_t waitValPresent;               // Whether above value is present.
 
   os_thread_id osThread;

--- a/RTXOff/rtxoff_os.h
+++ b/RTXOff/rtxoff_os.h
@@ -289,16 +289,7 @@ typedef struct {
   uint32_t max_used;                    ///< Maximum used
 } osRtxObjectMemUsage_t;
  
-/// OS Runtime Object Memory Usage variables
-extern osRtxObjectMemUsage_t osRtxThreadMemUsage;
-extern osRtxObjectMemUsage_t osRtxTimerMemUsage;
-extern osRtxObjectMemUsage_t osRtxEventFlagsMemUsage;
-extern osRtxObjectMemUsage_t osRtxMutexMemUsage;
-extern osRtxObjectMemUsage_t osRtxSemaphoreMemUsage;
-extern osRtxObjectMemUsage_t osRtxMemoryPoolMemUsage;
-extern osRtxObjectMemUsage_t osRtxMessageQueueMemUsage;
- 
- 
+
 //  ==== OS API definitions ====
  
 // Object Limits definitions

--- a/RTXOff/rtxoff_thread.cpp
+++ b/RTXOff/rtxoff_thread.cpp
@@ -248,7 +248,7 @@ void *osRtxThreadListRoot (osRtxThread_t *thread)
 /// \param[in]  thread          thread object.
 /// \param[in]  ret_val         return value.
 /// \param[in]  dispatch        dispatch flag.
-void osRtxThreadWaitExit(osRtxThread_t *thread, uint32_t ret_val, bool dispatch)
+void osRtxThreadWaitExit(osRtxThread_t *thread, uint64_t ret_val, bool dispatch)
 {
 	ThreadDispatcher::instance().delayListRemove(thread);
 	thread->waitExitVal = ret_val;

--- a/tests/arm-cmsis-rtos-validator/CMakeLists.txt
+++ b/tests/arm-cmsis-rtos-validator/CMakeLists.txt
@@ -5,7 +5,8 @@ set(CMSIS_RTOS_VALIDATOR_SOURCES
 	Source/RV_Signal.c
 	Source/RV_Report.c
 	Source/RV_Semaphore.c
-	Source/RV_Framework.c)
+	Source/RV_Framework.c
+	Source/RV_MemoryPool.c)
 
 add_executable(cmsis_rtos_validator ${CMSIS_RTOS_VALIDATOR_SOURCES})
 target_link_libraries(cmsis_rtos_validator rtxoff)

--- a/tests/arm-cmsis-rtos-validator/Source/Config/RTE_Components.h
+++ b/tests/arm-cmsis-rtos-validator/Source/Config/RTE_Components.h
@@ -16,7 +16,7 @@
         #define RTE_Compiler_IO_STDOUT_ITM      /* Compiler I/O: STDOUT ITM */
 // #define RTE_RV_GENWAIT                     /* RTOS Validation - GenWait test enabled */
 // #define RTE_RV_MAILQUEUE                   /* RTOS Validation - MailQueue test enabled */
-// #define RTE_RV_MEMORYPOOL                  /* RTOS Validation - MemoryPool test enabled */
+ #define RTE_RV_MEMORYPOOL                  /* RTOS Validation - MemoryPool test enabled */
 // #define RTE_RV_MSGQUEUE                    /* RTOS Validation - MsgQueue test enabled */
 #define RTE_RV_MUTEX                       /* RTOS Validation - Mutex test enabled */
 #define RTE_RV_SEMAPHORE                   /* RTOS Validation - Semaphore test enabled */


### PR DESCRIPTION
Implemented memory pools! I mostly copied the RTX implementation from Mbed source and fixed the errors that arose. 

A couple of things I'm uncertain on:

- Currently, it's using dynamic memory allocation for allocating the pools themselves
- I just copied the thread dispatch code from semaphore implementation; perhaps it's not correct
- A test requires RTXOff to return osErrorValue instead of osErrorParameter; I changed this but it's now inconsistent with Mbed's original implementation
- (resolved) _I didn't implement interrupt post-processing because I wasn't sure how_
- I commented out all event function calls

All CMSIS-Validator tests are passing